### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/library/vault_token.py
+++ b/library/vault_token.py
@@ -117,7 +117,7 @@ def get_auth_token(module, url, id):
 
     if info['status'] != 200:
         return False
-        module.fail_json(msg="Unable to fetch auth backend list (%s)" % info['msg'])
+        module.fail_json(msg="Unable to fetch auth backend list ({0!s})".format(info['msg']))
 
     return json.loads(response.read())
 
@@ -155,7 +155,7 @@ def token_present(module, url):
     response, info = fetch_url(module, auth_url, method='POST', headers=headers, data=data_json)
 
     if info['status'] != 204 and info['status'] != 200:
-        module.fail_json(msg="Unable to create token '%s' (%s)" % (module.params['id'], info['msg']))
+        module.fail_json(msg="Unable to create token '{0!s}' ({1!s})".format(module.params['id'], info['msg']))
 
     ret = json.loads(response.read())
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sidick:ansible_vault?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sidick:ansible_vault?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
